### PR TITLE
fix incorrect clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ### Installation
 
 ```bash
-git clone https://github.com/username/Zen-C.git
+git clone https://github.com/z-libs/Zen-C.git
 cd Zen-C
 make
 sudo make install


### PR DESCRIPTION
The clone URL provided in the README was incorrect. This commit updates it to the correct repository address to avoid confusion for users following the setup instructions.