### PR TITLE
Upgrade undefined variable diagnostics to hard errors

### DIFF
--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -427,15 +427,7 @@ void codegen_expression(ParserContext *ctx, ASTNode *node, FILE *out)
 
         if (node->resolved_type && strcmp(node->resolved_type, "unknown") == 0)
         {
-            if (node->var_ref.suggestion)
-            {
-                char msg[256];
-                sprintf(msg, "Undefined variable '%s'", node->var_ref.name);
-                char help[256];
-                sprintf(help, "Did you mean '%s'?", node->var_ref.suggestion);
-
-                zwarn_at(node->token, "%s\n   = help: %s", msg, help);
-            }
+            // Already handled by parser errors
         }
         fprintf(out, "%s", node->var_ref.name);
         break;

--- a/src/parser/parser_expr.c
+++ b/src/parser/parser_expr.c
@@ -1741,13 +1741,10 @@ ASTNode *parse_primary(ParserContext *ctx, Lexer *l)
             else
             {
                 node->resolved_type = xstrdup("unknown");
-                if (should_suppress_undef_warning(ctx, acc))
+                if (!should_suppress_undef_warning(ctx, acc))
                 {
-                    node->var_ref.suggestion = NULL;
-                }
-                else
-                {
-                    node->var_ref.suggestion = find_similar_symbol(ctx, acc);
+                    char *suggestion = find_similar_symbol(ctx, acc);
+                    error_undefined_variable(t, acc, suggestion);
                 }
             }
         }

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -266,6 +266,23 @@ void error_undefined_function(Token t, const char *func_name, const char *sugges
     }
 }
 
+void error_undefined_variable(Token t, const char *var_name, const char *suggestion)
+{
+    char msg[256];
+    sprintf(msg, "Undefined variable '%s'", var_name);
+
+    if (suggestion)
+    {
+        char help[512];
+        sprintf(help, "Did you mean '%s'?", suggestion);
+        zpanic_with_suggestion(t, msg, help);
+    }
+    else
+    {
+        zpanic_with_suggestion(t, msg, "Check if the variable is defined or in scope");
+    }
+}
+
 void error_wrong_arg_count(Token t, const char *func_name, int expected, int got)
 {
     char msg[256];

--- a/src/zprep.h
+++ b/src/zprep.h
@@ -134,6 +134,7 @@ void zpanic_with_suggestion(Token t, const char *msg, const char *suggestion);
 
 // Specific error types.
 void error_undefined_function(Token t, const char *func_name, const char *suggestion);
+void error_undefined_variable(Token t, const char *var_name, const char *suggestion);
 void error_wrong_arg_count(Token t, const char *func_name, int expected, int got);
 void error_undefined_field(Token t, const char *struct_name, const char *field_name,
                            const char *suggestion);


### PR DESCRIPTION
This PR changes undefined variable diagnostics from warnings to hard errors to improve 'fail-fast' developer experience and prevent confusing C compilation errors.