### PR TITLE
Made compiler consider variables immutable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,9 @@ var explicit: float = 1.0;  // Explicit type
 ```
 
 #### Mutability
-By default, variables are mutable. You can enable **Immutable by Default** mode using a directive.
+By default, variables are immutable. You can enable **Mutable by Default** mode using a directive.
 
 ```zc
-//> immutable-by-default
-
 var x = 10;
 // x = 20; // Error: x is immutable
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -241,7 +241,7 @@ struct ParserContext
     ImportedPlugin *imported_plugins; // Plugin imports
 
     // Config/State
-    int immutable_by_default;
+    int mutable_by_default;
     char *current_impl_struct;
 
     // Internal tracking

--- a/src/parser/parser_stmt.c
+++ b/src/parser/parser_stmt.c
@@ -864,7 +864,7 @@ ASTNode *parse_var_decl(ParserContext *ctx, Lexer *l)
     else
     {
         // Default mutability depends on directive
-        is_mutable = !ctx->immutable_by_default;
+        is_mutable = ctx->mutable_by_default;
     }
 
     // Destructuring: var {x, y} = ...

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -687,9 +687,9 @@ void scan_build_directives(ParserContext *ctx, const char *src)
                     strcat(g_link_flags, flags);
                 }
             }
-            else if (strncmp(line, "immutable-by-default", 20) == 0)
+            else if (strncmp(line, "mutable-by-default", 18) == 0)
             {
-                ctx->immutable_by_default = 1;
+                ctx->mutable_by_default = 1;
             }
 
             p += len;


### PR DESCRIPTION
The compiler will now consider all variables immutable by default.
The `immutable-by-default` directive was replaced by `mutable-by-default`, which does as specified.