### PR TITLE
fix(main.c): update the search paths printing function to reflect the actual values

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,8 @@ void print_search_paths()
     printf("Search paths:\n");
     printf("  ./\n");
     printf("  ./std/\n");
-    printf("  /usr/local/lib/zen/\n");
+    printf("  /usr/local/share/zenc\n");
+    printf("  /usr/share/zenc\n");
 }
 
 void print_usage()


### PR DESCRIPTION
Hi,
I just noticed that the `print_search_paths` is a bit outdated, even though it isn't used anywhere in the code yet, it caused me some headache when i was trying to figure out where i have to install the `std` to make the `zenc-git` AUR package

and thanks for this cool project

- Anas