### PR TITLE
Added union wrapper for type specific AST members.

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -54,10 +54,12 @@ typedef struct Type
     struct Type **args; // For GENERIC args.
     int arg_count;
     int is_const;
-    int array_size;  // For fixed-size arrays [T; N].
-    int is_varargs;  // For function types (...).
-    int is_restrict; // For restrict pointers.
-    int has_drop;    // For RAII: does this type implement Drop?
+    union {
+        int array_size;  // For fixed-size arrays [T; N].
+        int is_varargs;  // For function types (...).
+        int is_restrict; // For restrict pointers.
+        int has_drop;    // For RAII: does this type implement Drop?
+    };
 } Type;
 
 // ** AST Node Types **


### PR DESCRIPTION
There is no reason allocating more memory for type specific AST members. Code already checks for the type so i've wrapped the members with a union.