### PR TITLE
Add `--version` / `-V` flag to zc CLI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,11 @@ void print_search_paths()
     printf("  /usr/share/zenc\n");
 }
 
+void print_version()
+{
+    printf("Zen C version %s\n", ZEN_VERSION);
+}
+
 void print_usage()
 {
     printf("Usage: zc [command] [options] <file.zc>\n");
@@ -32,6 +37,7 @@ void print_usage()
     printf("  transpile Transpile to C code only (no compilation)\n");
     printf("  lsp     Start Language Server\n");
     printf("Options:\n");
+    printf("  --version       Print version information");
     printf("  -o <file>       Output executable name\n");
     printf("  --emit-c        Keep generated C file (out.c)\n");
     printf("  --freestanding  Freestanding mode (no stdlib)\n");
@@ -118,6 +124,11 @@ int main(int argc, char **argv)
         if (strcmp(arg, "--emit-c") == 0)
         {
             g_config.emit_c = 1;
+        }
+        else if (strcmp(arg, "--version") == 0|| strcmp(arg, "-V") == 0)
+        {
+            print_version();
+            return 0;
         }
         else if (strcmp(arg, "--verbose") == 0 || strcmp(arg, "-v") == 0)
         {

--- a/src/zprep.h
+++ b/src/zprep.h
@@ -8,6 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+// **ZEN VERSION**
+#define ZEN_VERSION "0.1.0"
+
 // ** ANSI COLORS **
 #define COLOR_RESET "\033[0m"
 #define COLOR_RED "\033[1;31m"


### PR DESCRIPTION
This PR adds a `--version` / `-V` flag to the `zc` CLI, allowing users to query the compiler version directly from the command line.

## Changes
- Introduce a `ZEN_VERSION` macro to centralize version information
- Add `--version` and `-V` flags to the CLI argument parser
- Print version information and exit cleanly