### PR TITLE
README: Fix ternary operator example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ if x > 10 {
 }
 
 // Ternary
-var y = if x > 10 ? 1 : 0;
+var y = x > 10 ? 1 : 0;
 ```
 
 #### Pattern Matching


### PR DESCRIPTION
Fixes the ternary operator example syntax in the README which was wrong and copying it would cause compilation error like:
```
out.c:2356:21: error: expected expression before ‘if’
 2356 |     __auto_type y = if;
```