### PR TITLE
docs(readme): fix input prompt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ Zen C supports a shorthand for prompting user input using the `?` prefix.
     - Format specifiers are automatically inferred based on variable type.
 
 ```c
-var age = "How old are you? ";
+var age: int;
+? "How old are you? " (age);
 println "You are {age} years old.";
 ```
 


### PR DESCRIPTION
the `?` was missing from the snippet code