### PR TITLE
chore(gitattributes): Use C syntax highlighting for .zc files in linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zc linguist-language=C


### PR DESCRIPTION
In order to have Github highlight the .zc files, we configure the linguist backend via .gitattributes. This will highlight .zc files with C syntax until Zen-C is officially recognized on [Githubs linguist repo](https://github.com/github-linguist/linguist/pulls).

---

Before:

<img width="947" height="781" alt="image" src="https://github.com/user-attachments/assets/25cf26af-de09-4abd-bd3b-e46be1b7c367" />

After:

<img width="852" height="794" alt="image" src="https://github.com/user-attachments/assets/6007f989-7278-4808-9a44-106e81c42175" />

---

@Zuhaitz-dev once you deem the language stable in the future, you can open a [PR ](https://github.com/github-linguist/linguist/pulls) and have Github integrate Zen-C as an official language in the linguist.