### PR TITLE
propagate return code when using zc `run` subcommand on POSIX

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -356,7 +356,11 @@ int main(int argc, char **argv)
         remove(outfile);
         zptr_plugin_mgr_cleanup();
         zen_trigger_global();
+#if defined(WIFEXITED) && defined(WEXITSTATUS)
+        return WIFEXITED(ret) ? WEXITSTATUS(ret) : ret;
+#else
         return ret;
+#endif
     }
 
     zptr_plugin_mgr_cleanup();


### PR DESCRIPTION
On POSIX systems, the return value of the system function from stdlib is a packed value, and requires the WEXITSTATUS macro to unpack the return code of the program that the system function ran.