### PR TITLE
open_memstream -> tmpfile

### DIFF
--- a/src/parser/parser_stmt.c
+++ b/src/parser/parser_stmt.c
@@ -1413,10 +1413,15 @@ char *process_printf_sugar(ParserContext *ctx, const char *content, int newline,
                     {
                         char *inner_c = NULL;
                         size_t len = 0;
-                        FILE *ms = open_memstream(&inner_c, &len);
+                        FILE *ms = tmpfile();
                         if (ms)
                         {
                             codegen_expression(ctx, expr_node, ms);
+                            len = ftell(ms);
+                            fseek(ms, 0, SEEK_SET);
+                            inner_c = xmalloc(len + 1);
+                            fread(inner_c, 1, len, ms);
+                            inner_c[len] = 0;
                             fclose(ms);
                         }
 
@@ -1443,10 +1448,15 @@ char *process_printf_sugar(ParserContext *ctx, const char *content, int newline,
             {
                 char *buf = NULL;
                 size_t len = 0;
-                FILE *ms = open_memstream(&buf, &len);
+                FILE *ms = tmpfile();
                 if (ms)
                 {
                     codegen_expression(ctx, expr_node, ms);
+                    len = ftell(ms);
+                    fseek(ms, 0, SEEK_SET);
+                    buf = xmalloc(len + 1);
+                    fread(buf, 1, len, ms);
+                    buf[len] = 0;
                     fclose(ms);
                     rw_expr = buf;
                     used_codegen = 1;

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -2108,10 +2108,15 @@ char *process_fstring(ParserContext *ctx, const char *content, char ***used_syms
         // Codegen expression to temporary buffer
         char *code_buffer = NULL;
         size_t code_len = 0;
-        FILE *mem_stream = open_memstream(&code_buffer, &code_len);
+        FILE *mem_stream = tmpfile();
         if (mem_stream)
         {
             codegen_expression(ctx, expr_node, mem_stream);
+            code_len = ftell(mem_stream);
+            code_buffer = xmalloc(code_len + 1);
+            fseek(mem_stream, 0, SEEK_SET);
+            fread(code_buffer, 1, code_len, mem_stream);
+            code_buffer[code_len] = 0;
             fclose(mem_stream);
         }
 


### PR DESCRIPTION
Let's merge Windows support by smaller steps :)
Non-supported open_memstream is replaced with tmpfile.
Tests are passed in #20 