### PR TITLE
codegen: Emit 'main()' return type as C_INT

### DIFF
--- a/src/parser/parser_decl.c
+++ b/src/parser/parser_decl.c
@@ -111,7 +111,7 @@ ASTNode *parse_function(ParserContext *ctx, Lexer *l, int is_async)
     if (strcmp(name, "main") == 0)
     {
         ret = "int";
-        ret_type_obj = type_new(TYPE_INT);
+        ret_type_obj = type_new(TYPE_C_INT);
     }
 
     if (lexer_peek(l).type == TOK_ARROW)


### PR DESCRIPTION
Return type of main function in C is defined as `int`. Returning `i32` causes a compiler warning on architectures that don't define `int32_t` as `int`. 