### PR TITLE
Add 'make clean' command to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Join the discussion, share demos, ask questions, or report bugs in the official 
 ```bash
 git clone https://github.com/z-libs/Zen-C.git
 cd Zen-C
+make clean
 make
 sudo make install
 ```


### PR DESCRIPTION
The build produced a faulty binary because I had switched between the `v0.4.0` tag and the `HEAD` of `main` - this command will slow subsequent builds, but I think compiler devs will know not to do that? Otherwise maybe add a note about it...