### PR TITLE
Remove '_lmaginary' ('L' + 'maginary') from C reserved-keywords list

### DIFF
--- a/docs/lex.md
+++ b/docs/lex.md
@@ -107,7 +107,7 @@ CReserved   ::= "auto" | "case" | "char" | "default" | "do" | "double"
               | "extern" | "float" | "inline" | "int" | "long" | "register" 
               | "restrict" | "short" | "signed" | "switch" | "typedef" 
               | "unsigned" | "void" | "_Atomic" | "_Bool" | "_Complex" 
-              | "_Generic" | "_Imaginary" | "_lmaginary" | "_Noreturn" 
+              | "_Generic" | "_Imaginary" | "_Noreturn" 
               | "_Static_assert" | "_Thread_local"
 
 LogicOp     ::= "and" | "or"


### PR DESCRIPTION
In the next code:

https://github.com/z-libs/Zen-C/blob/1c2cc175fffea4c4208a5f1f94ed4d152eaf93c5/src/parser/parser_utils.c#L231-L239

`"_lmaginary"` not present and lools like a misspelling.