### PR TITLE
Fix std library imports when using ZC_ROOT

### DIFF
--- a/src/parser/parser_stmt.c
+++ b/src/parser/parser_stmt.c
@@ -3226,13 +3226,17 @@ ASTNode *parse_import(ParserContext *ctx, Lexer *l)
     if (access(fn, R_OK) != 0)
     {
         // Try system-wide standard library location
-        static const char *system_paths[] = {"/usr/local/share/zenc", "/usr/share/zenc", NULL};
+        const char *system_paths[] = {getenv("ZC_ROOT"), "/usr/local/share/zenc",
+                                      "/usr/share/zenc"};
+        size_t system_paths_count = sizeof(system_paths) / sizeof(*system_paths);
 
         char system_path[1024];
         int found = 0;
 
-        for (int i = 0; system_paths[i] && !found; i++)
+        for (size_t i = 0; i < system_paths_count && !found; i++)
         {
+            if (!system_paths[i])
+                continue;
             snprintf(system_path, sizeof(system_path), "%s/%s", system_paths[i], fn);
             if (access(system_path, R_OK) == 0)
             {


### PR DESCRIPTION
Related to the problem described here: https://gist.github.com/mhcerri/0588437ad7fbe183fe893a7d41df98a0

That's just the minimal fix to make `ZC_ROOT` work when pointing to a custom path. If you prefer to refactor how parse_import() and load_file() work or maybe replace realpath(), please let me know. But I believe this fix is correct either way.

Another improvement to consider is to maybe base the PREFIX into a `config.h`, for instance and make that part of the list of system paths. This way the code doesn't need to rely on env vars or fixed locations.

Thank you for the really interesting project!

---
Currently, the parser tries to avoid the inclusion of duplicated files by normalizing import names using realpath(). However, that only works if the file path points to a real file.

Since the parser doesn't consider ZC_ROOT as part of the system paths when searching for the imported file, realpath() can't normalize imports to the standard library when using ZC_ROOT. That causes some files to be wrongly included more than once. This happens because "core.zc", for example, can be included directly as "std/core.zc" and indirectly from another source file under std/ as "./core.zc", resulting in "std/./core.zc", which won't be normalized by realpath() unless ZC_ROOT is pre-appended.

Update parse_import() to consider ZC_ROOT as one of the system base paths for the standard library and bring it in line with the same import paths used by load_file() from "src/utils/utils.c".

Although this change keeps parse_import() and load_file() consistent, further improvements can be made in the future so both functions can share the same system paths and realpath() can be replaced by a hand-crafted function that is able to normalize file paths, even if they don't exist.