### PR TITLE
Fix for #214

### DIFF
--- a/src/parser/parser_expr.c
+++ b/src/parser/parser_expr.c
@@ -2757,6 +2757,30 @@ ASTNode *parse_primary(ParserContext *ctx, Lexer *l)
 
                     ASTNode *arg = parse_expression(ctx, l);
 
+                    // Move Semantics Logic
+                    check_move_usage(ctx, arg, arg ? arg->token : t1);
+                    if (arg && arg->type == NODE_EXPR_VAR)
+                    {
+                        Type *t = find_symbol_type_info(ctx, arg->var_ref.name);
+                        if (!t)
+                        {
+                            ZenSymbol *s = find_symbol_entry(ctx, arg->var_ref.name);
+                            if (s)
+                            {
+                                t = s->type_info;
+                            }
+                        }
+
+                        if (!is_type_copy(ctx, t))
+                        {
+                            ZenSymbol *s = find_symbol_entry(ctx, arg->var_ref.name);
+                            if (s)
+                            {
+                                s->is_moved = 1;
+                            }
+                        }
+                    }
+
                     // Implicit trait cast logic
                     if (sig && args_provided < sig->total_args && arg)
                     {
@@ -3102,6 +3126,30 @@ ASTNode *parse_primary(ParserContext *ctx, Lexer *l)
                     }
 
                     ASTNode *arg = parse_expression(ctx, l);
+
+                    // Move Semantics Logic
+                    check_move_usage(ctx, arg, arg ? arg->token : t1);
+                    if (arg && arg->type == NODE_EXPR_VAR)
+                    {
+                        Type *t = find_symbol_type_info(ctx, arg->var_ref.name);
+                        if (!t)
+                        {
+                            ZenSymbol *s = find_symbol_entry(ctx, arg->var_ref.name);
+                            if (s)
+                            {
+                                t = s->type_info;
+                            }
+                        }
+
+                        if (!is_type_copy(ctx, t))
+                        {
+                            ZenSymbol *s = find_symbol_entry(ctx, arg->var_ref.name);
+                            if (s)
+                            {
+                                s->is_moved = 1;
+                            }
+                        }
+                    }
 
                     if (!head)
                     {

--- a/tests/language/features/test_use_after_move_call.zc
+++ b/tests/language/features/test_use_after_move_call.zc
@@ -1,0 +1,15 @@
+// EXPECT: FAIL
+
+struct Mover {
+  val: int
+}
+
+fn consume(m: Mover) {
+  println "m.val = {m.val}"
+}
+
+fn main() {
+  let m = Mover { val: 10 }
+  consume(m)
+  consume(m)
+}


### PR DESCRIPTION
## Description
Fixes issue #214 : use-after-move in function calls was not rejected in default compile path.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
