### PR TITLE
Exclude Xcode generated debug symbols from gitignore when building Zen C on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ a.out
 *.dll
 *.dylib
 *.a
+*.so.dSYM/
 .vscode/
 .idea/
 *.swp


### PR DESCRIPTION
## Description
When the project is built on Mac, for each C file in the plugins/ folder Xcode generates a folder called <plugin>.so.dSYM with .plist and .yml metadata that should remain local to the developer's machine. This change adds a `*.so.dSYM` exclusion to the .gitignore to exclude them from the repository.

<img width="298" height="547" alt="image" src="https://github.com/user-attachments/assets/50973084-3048-4b85-8219-01148a3ed21f" />

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
