### PR TITLE
Fix unit test test_asm_arm64 introduced in 15e31d

### DIFF
--- a/tests/language/features/test_asm_arm64.zc
+++ b/tests/language/features/test_asm_arm64.zc
@@ -8,9 +8,9 @@ fn test_yield() {
 
 fn test_multiline() {
     asm {
-        mov x0, 1
-        mov x1, 2
-        add x0, x0, x1
+        "mov x0, #1"
+        "mov x1, #2"
+        "add x0, x0, x1"
     }
 }
 
@@ -34,7 +34,7 @@ test "test_asm_arm64" {
 fn add_five(x: int) -> int {
     let result: int;
     asm {
-        "add {result}, {x}, 5"
+        "add {result}, {x}, #5"
         : out(result)
         : in(x)
     }


### PR DESCRIPTION
## Description
This fixes the new unit test test_asm_arm64 on arm64 cpus introduced in 15e31d. This change makes all unit tests pass on arm64 architectures as tested on Apple M2 Air.

Please note that this unit test still triggers C warnings due to arm64 defaulting to a 64-bit register for a 32-bit C integer and this should be addressed in the transpiler. I will open an issue for this.

```c
out.c:146:16: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
  146 |         : "=r"(result)
      |                ^
out.c:145:18: note: use constraint modifier "w"
  145 |     __asm__("add %0, %1, #5\n"
      |                  ^~
      |                  %w0
out.c:147:15: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
  147 |         : "r"(x));
      |               ^
out.c:145:22: note: use constraint modifier "w"
  145 |     __asm__("add %0, %1, #5\n"
      |                      ^~
      |                      %w1
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
