### PR TITLE
fix pointer arithmetic bug in std/queue.zc

### DIFF
--- a/std/queue.zc
+++ b/std/queue.zc
@@ -27,7 +27,7 @@ impl Queue<T> {
 
   fn _grow(self) {
     let new_cap = (self.cap == 0) ? 8 : self.cap * 2;
-    let new_data = malloc(sizeof(T) * new_cap);
+    let new_data: T* = malloc(sizeof(T) * new_cap);
     
     if (self.count > 0) {
         if (self.tail > self.head) {

--- a/tests/lib/std/test_queue.zc
+++ b/tests/lib/std/test_queue.zc
@@ -70,20 +70,15 @@ test "Queue Ring Buffer (Advanced)" {
     q.push(3);
     assert(*q.pop().unwrap_ref() == 1);
     
-    println "Pushing until capacity (assume 8)"
-    q.push(4); q.push(5); q.push(6); q.push(7); q.push(8); q.push(9);
+    println "Pushing just over capacity (assume 8)"
+    q.push(4); q.push(5); q.push(6); q.push(7); q.push(8); q.push(9); q.push(10);
     
-    println "Popping some to advance head"
-    assert(*q.pop().unwrap_ref() == 2);
-    assert(*q.pop().unwrap_ref() == 3);
-    
-    println "Pushing to wrap tail"
-    q.push(10);
-    q.push(11);
-    
-    while (!q.is_empty()) {
-        q.pop();
+    println "Testing grow logic when tail is behind head"
+    for i in 2..=10 {
+        assert(*q.pop().unwrap_ref() == i);
     }
+
+    assert(q.is_empty());
     
     println "Testing clear"
     q.push(100);


### PR DESCRIPTION
## Description
In the `Queue::_grow()` method, the pointer type of the newly allocated buffer was unspecified, making the type `void*` in the resulting C code. Later in this method, a pointer addition is performed with that pointer, which assumes that the size of the array element type is 1 byte instead of however many bytes `T` is.

This commit specifies the type of the pointer as `T*`, which makes the pointer arithmetic performed on it valid for all `T`. I've also updated the unit test to be able to catch this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
