### PR TITLE
Avoid failing typecheck on trusted imports

### DIFF
--- a/src/parser/parser_expr.c
+++ b/src/parser/parser_expr.c
@@ -2076,6 +2076,8 @@ ASTNode *parse_primary(ParserContext *ctx, Lexer *l)
                             tmp[suffix.len] = 0;
                             free(acc);
                             acc = tmp;
+
+                            register_extern_symbol(ctx, acc);
                         }
 
                         else


### PR DESCRIPTION
## Description
Marks trusted imports as external symbols so they don't clash with `--typecheck`.

Before this fix, the below code would fail to compile due to `undefined function InitWindow` (etc.) if built with `--typecheck`.

This brings the compiler in line with the README during typecheck:

> This treats the header as a module and assumes all symbols accessed through it exist.

```c
//> include: ./includes
//> lib: ./libs
//> link: -lraylib
//> macos: framework: Cocoa
//> macos: framework: CoreFoundation
//> macos: framework: IOKit

import "raylib.h" as rl;

fn main() {
    rl::InitWindow(800, 600, "Zen C Game");
    defer rl::CloseWindow();

    rl::SetTargetFPS(30);

    while !rl::WindowShouldClose()
    {
        rl::BeginDrawing();
        rl::ClearBackground(GRAY);
        rl::DrawText("Zen C + Raylib Demo!", 250, 20, 30, BLACK);
        rl::DrawFPS(10, 10);
        rl::EndDrawing();
    }
}
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
