### PR TITLE
Don't treat trusted import as unknown type when referenced as struct member type

### DIFF
--- a/src/parser/parser_type.c
+++ b/src/parser/parser_type.c
@@ -84,6 +84,8 @@ Type *parse_type_base(ParserContext *ctx, Lexer *l)
                     // To prevent name mangling, we might consider changing
                     // this to also use the prefix.
                     merged = xstrdup(resolved_suffix);
+
+                    register_extern_symbol(ctx, merged);
                 }
                 else
                 {

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -4417,14 +4417,20 @@ int validate_types(ParserContext *ctx)
     while (u)
     {
         ASTNode *def = find_struct_def(ctx, u->name);
-        const char *alias = find_type_alias(ctx, u->name);
-
-        if (!def && !alias)
+        if (!def)
         {
-            SelectiveImport *si = find_selective_import(ctx, u->name);
-            if (!si && !is_trait(u->name))
+            const char *alias = find_type_alias(ctx, u->name);
+            if (!alias)
             {
-                zwarn_at(u->location, "Unknown type '%s' (assuming external C struct)", u->name);
+                SelectiveImport *si = find_selective_import(ctx, u->name);
+                if (!si && !is_extern_symbol(ctx, u->name))
+                {
+                    if (!is_trait(u->name))
+                    {
+                        zwarn_at(u->location, "Unknown type '%s' (assuming external C struct)",
+                                 u->name);
+                    }
+                }
             }
         }
         u = u->next;


### PR DESCRIPTION
## Description
Marks trusted imports as external symbols so `--typecheck` doesn't output `Unknown type '%s' (assuming external C struct)` when it doesn't have to assume.

This brings the compiler in line with the README during typecheck but with zero warnings:

> This treats the header as a module and assumes all symbols accessed through it exist.

I reordered `validate_types` to avoid searching `find_type_alias` if it found a struct by that name, and chose to put `is_extern_symbol` before `is_trait` as I expect it to be a cheaper search for all projects (like `find_selective_import`), but as `is_trait` is more likely to return a match I can swap them back around if desired.

```c
import "raylib.h" as rl;

struct ZImage {
    image: rl::Image;
}
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
