### PR TITLE
fix issue #137

### DIFF
--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -399,41 +399,10 @@ void codegen_expression(ParserContext *ctx, ASTNode *node, FILE *out)
                     fprintf(out, ")");
                 }
             }
-            else if (t1 && (strcmp(t1, "string") == 0)
+            else if (t1 && (strcmp(t1, "string") == 0))
             {
-                int is_null_compare = 0;
-                if (node->binary.right->type == NODE_EXPR_VAR &&
-                    strcmp(node->binary.right->var_ref.name, "NULL") == 0)
-                {
-                    is_null_compare = 1;
-                }
-                else if (node->binary.left->type == NODE_EXPR_VAR &&
-                         strcmp(node->binary.left->var_ref.name, "NULL") == 0)
-                {
-                    is_null_compare = 1;
-                }
-                else if (node->binary.right->type == NODE_EXPR_LITERAL &&
-                         node->binary.right->literal.type_kind == LITERAL_INT &&
-                         node->binary.right->literal.int_val == 0)
-                {
-                    is_null_compare = 1;
-                }
-                else if (node->binary.left->type == NODE_EXPR_LITERAL &&
-                         node->binary.left->literal.type_kind == LITERAL_INT &&
-                         node->binary.left->literal.int_val == 0)
-                {
-                    is_null_compare = 1;
-                }
-
-                if (is_null_compare)
-                {
-                    fprintf(out, "(");
-                    codegen_expression(ctx, node->binary.left, out);
-                    fprintf(out, " %s ", node->binary.op);
-                    codegen_expression(ctx, node->binary.right, out);
-                    fprintf(out, ")");
-                }
-                else
+                char *t2 = infer_type(ctx, node->binary.right);
+                if (t2 && (strcmp(t2, "string") == 0))
                 {
                     fprintf(out, "(strcmp(");
                     codegen_expression(ctx, node->binary.left, out);
@@ -447,6 +416,14 @@ void codegen_expression(ParserContext *ctx, ASTNode *node, FILE *out)
                     {
                         fprintf(out, ") != 0)");
                     }
+                }
+                else
+                {
+                    fprintf(out, "(");
+                    codegen_expression(ctx, node->binary.left, out);
+                    fprintf(out, " %s ", node->binary.op);
+                    codegen_expression(ctx, node->binary.right, out);
+                    fprintf(out, ")");
                 }
             }
             else


### PR DESCRIPTION
## Description
Update codegen.c to address issue #137.
String comparisons now happen by value,
while char* comparisons use addresses.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
