### PR TITLE
Fix @derive not working on opaque structs

### DIFF
--- a/src/parser/parser_core.c
+++ b/src/parser/parser_core.c
@@ -658,13 +658,6 @@ ASTNode *parse_program_nodes(ParserContext *ctx, Lexer *l)
                         s->type_info->kind = TYPE_VECTOR;
                         s->type_info->array_size = attr_vector_size;
                     }
-
-                    if (derived_count > 0)
-                    {
-                        ASTNode *impls =
-                            generate_derive_impls(ctx, s, derived_traits, derived_count);
-                        s->next = impls;
-                    }
                 }
             }
             else if (0 == strncmp(t.start, "enum", 4) && 4 == t.len)
@@ -850,7 +843,6 @@ ASTNode *parse_program_nodes(ParserContext *ctx, Lexer *l)
                 zpanic_at(next, "Expected 'fn' after 'async'");
             }
         }
-
         else if (t.type == TOK_UNION)
         {
             s = parse_struct(ctx, l, 1, 0);
@@ -907,8 +899,7 @@ ASTNode *parse_program_nodes(ParserContext *ctx, Lexer *l)
                 }
             }
         }
-
-        if (s && s->type == NODE_STRUCT)
+        else if (s && s->type == NODE_STRUCT)
         {
             s->strct.is_export = attr_export;
             s->strct.attributes = current_custom_attributes;
@@ -920,6 +911,11 @@ ASTNode *parse_program_nodes(ParserContext *ctx, Lexer *l)
             if (attr_deprecated && s->strct.name)
             {
                 register_deprecated_func(ctx, s->strct.name, deprecated_msg);
+            }
+            if (derived_count > 0)
+            {
+                ASTNode *impls = generate_derive_impls(ctx, s, derived_traits, derived_count);
+                s->next = impls;
             }
         }
 

--- a/tests/language/features/test_smart_derive.zc
+++ b/tests/language/features/test_smart_derive.zc
@@ -4,6 +4,11 @@ struct Container {
     val: int;
 }
 
+@derive(Eq)
+opaque struct OpaqueContainer {
+    val: int;
+}
+
 // Ensure derived eq uses pointers by trying to use 'c2' after comparison
 test "eq_moves" {
     let c1 = Container { val: 10 };
@@ -23,4 +28,25 @@ test "eq_moves" {
     assert(c2.val == 20, "c2 invalid");
     
     println "Smart Derive Eq Works!";
+}
+
+// Ensure eq is derived correctly on opaque structs also
+test "eq_moves_opaque" {
+    let c1 = OpaqueContainer { val: 10 };
+    let c2 = OpaqueContainer { val: 10 };
+    
+    // This should call OpaqueContainer__eq(&c1, &c2)
+    // If it passed by value, c2 would be moved here
+    if c1 == c2 {
+        // c2 must still be valid
+        assert(c2.val == 10, "c2 moved during equality check in opaque struct!");
+    } else {
+        assert(false, "c1 != c2 in opaque struct");
+    }
+    
+    // Explicitly verify c2 is still valid
+    c2.val = 20;
+    assert(c2.val == 20, "c2 invalid in opaque struct");
+    
+    println "Smart Derive Eq Works in opaque struct!";
 }


### PR DESCRIPTION
## Description
Due to `generate_derive_impls` only being called in the branch for handling the "struct" keyword, the branch that handles the "opaque" keyword (and consumes the following "struct" directly) didn't support `@derive`.

```c
@derive(Eq)
opaque struct OpaqueContainer {
    val: int;
}
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
