### PR TITLE
Register extern struct/union symbols

### DIFF
--- a/src/parser/parser_core.c
+++ b/src/parser/parser_core.c
@@ -1141,6 +1141,7 @@ ASTNode *parse_program_nodes(ParserContext *ctx, Lexer *l)
                     // extern struct Name; -> opaque struct declaration
                     s = parse_struct(ctx, l, 0, 1);
                     register_extern_symbol(ctx, s->strct.name);
+                    s = NULL;
                 }
                 else if ((peek.type == TOK_IDENT && peek.len == 5 &&
                           strncmp(peek.start, "union", 5) == 0) ||
@@ -1149,6 +1150,7 @@ ASTNode *parse_program_nodes(ParserContext *ctx, Lexer *l)
                     // extern union Name; -> opaque union declaration
                     s = parse_struct(ctx, l, 1, 1);
                     register_extern_symbol(ctx, s->strct.name);
+                    s = NULL;
                 }
                 else
                 {


### PR DESCRIPTION
## Description
**Please see the 2nd commit.** I don't think it's a correct change, but I noticed that extern struct/unions were still emitted into the C output as a `typedef` which causes double-typedefs for structs defined in a C header. I don't see any unit tests using `extern struct/union` to verify its behavior so I'm not sure if this is intended or a bug. It makes my use-case below work.

This registers `extern struct` and `extern union` as known extern symbols to quench the warning "assuming external C struct". I didn't change the branch for `extern fn` because they don't seem to have this issue.

```c
#include "c_header_that_defines_dmon_structs.h"

extern struct dmon_watch_id;
extern struct dmon_action;

alias FsCallback = fn(dmon_watch_id, dmon_action, const char*, const char*, const char*, void*);
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
