### PR TITLE
fix: add parser-level checks for duplicate concrete struct definitions

### DIFF
--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -772,6 +772,11 @@ void register_tuple(ParserContext *ctx, const char *sig);
 ASTNode *find_struct_def(ParserContext *ctx, const char *name);
 
 /**
+ * @brief Finds an already-registered concrete struct definition.
+ */
+ASTNode *find_concrete_struct_def(ParserContext *ctx, const char *name);
+
+/**
  * @brief Registers a struct definition.
  */
 void register_struct_def(ParserContext *ctx, const char *name, ASTNode *node);

--- a/src/parser/parser_struct.c
+++ b/src/parser/parser_struct.c
@@ -873,6 +873,7 @@ ASTNode *parse_struct(ParserContext *ctx, Lexer *l, int is_union, int is_opaque)
     Token n = lexer_next(l);
     check_identifier(ctx, n);
     char *name = token_strdup(n);
+    Token name_token = n;
 
     // Generic Params <T> or <K, V>
     char **gps = NULL;
@@ -1083,9 +1084,6 @@ ASTNode *parse_struct(ParserContext *ctx, Lexer *l, int is_union, int is_opaque)
         }
     }
 
-    ASTNode *node = ast_create(NODE_STRUCT);
-    add_to_struct_list(ctx, node);
-
     // Auto-prefix struct name if in module context
     if (ctx->current_module_prefix && gp_count == 0)
     { // Don't prefix generic templates
@@ -1094,6 +1092,19 @@ ASTNode *parse_struct(ParserContext *ctx, Lexer *l, int is_union, int is_opaque)
         free(name);
         name = prefixed_name;
     }
+
+    // Generic templates are registered separately and may share the base name.
+    if (gp_count == 0)
+    {
+        ASTNode *existing = find_concrete_struct_def(ctx, name);
+        if (existing)
+        {
+            zpanic_at(name_token, "Redefinition of %s '%s'", is_union ? "union" : "struct", name);
+        }
+    }
+
+    ASTNode *node = ast_create(NODE_STRUCT);
+    add_to_struct_list(ctx, node);
 
     node->strct.name = name;
 

--- a/src/parser/parser_utils.c
+++ b/src/parser/parser_utils.c
@@ -1208,6 +1208,54 @@ ASTNode *find_struct_def(ParserContext *ctx, const char *name)
     return NULL;
 }
 
+ASTNode *find_concrete_struct_def(ParserContext *ctx, const char *name)
+{
+    Instantiation *i = ctx->instantiations;
+    while (i)
+    {
+        if (strcmp(i->name, name) == 0 && i->struct_node && i->struct_node->type == NODE_STRUCT &&
+            !i->struct_node->strct.is_template)
+        {
+            return i->struct_node;
+        }
+        i = i->next;
+    }
+
+    ASTNode *s = ctx->instantiated_structs;
+    while (s)
+    {
+        if (s->type == NODE_STRUCT && !s->strct.is_template && strcmp(s->strct.name, name) == 0)
+        {
+            return s;
+        }
+        s = s->next;
+    }
+
+    StructRef *r = ctx->parsed_structs_list;
+    while (r)
+    {
+        if (r->node->type == NODE_STRUCT && !r->node->strct.is_template &&
+            strcmp(r->node->strct.name, name) == 0)
+        {
+            return r->node;
+        }
+        r = r->next;
+    }
+
+    StructDef *d = ctx->struct_defs;
+    while (d)
+    {
+        if (d->node && d->node->type == NODE_STRUCT && !d->node->strct.is_template &&
+            strcmp(d->name, name) == 0)
+        {
+            return d->node;
+        }
+        d = d->next;
+    }
+
+    return NULL;
+}
+
 Module *find_module(ParserContext *ctx, const char *alias)
 {
     Module *m = ctx->modules;

--- a/tests/language/features/test_redefinition_struct.zc
+++ b/tests/language/features/test_redefinition_struct.zc
@@ -1,0 +1,14 @@
+// EXPECT: FAIL
+// Test: struct redefinition should be illegal
+
+struct Point {
+    x: int;
+    y: int;
+}
+
+struct Point {
+    a: int;
+    b: int;
+}
+
+fn main() {}


### PR DESCRIPTION
## Description
  Partially addresses #178

  - Add `find_concrete_struct_def()` for concrete struct lookup
  - Reject duplicate concrete struct definitions during parsing
  - Add `test_redefinition_struct.zc`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
