### PR TITLE
LSP: guard unresolved imports in fault-tolerant parse

### DIFF
--- a/src/parser/parser_stmt.c
+++ b/src/parser/parser_stmt.c
@@ -4154,6 +4154,15 @@ ASTNode *parse_import(ParserContext *ctx, Lexer *l)
     free(fn);
     fn = resolved;
 
+    // In fault-tolerant LSP mode zpanic_at reports the diagnostic and returns.
+    // Bail out here instead of dereferencing a NULL path below.
+    if (!fn)
+    {
+        ASTNode *dummy = ast_create(NODE_BLOCK);
+        dummy->block.statements = NULL;
+        return dummy;
+    }
+
     if (is_file_imported(ctx, fn))
     {
         free(fn);


### PR DESCRIPTION
## Summary
Guard `parse_import()` against a `NULL` resolved path after `zpanic_at()` returns in fault-tolerant LSP mode.

## Why
When an import cannot be resolved during LSP parsing, `zpanic_at()` reports the error and returns instead of exiting. The import parser was still falling through into later logic that assumes a valid resolved path. This hardens the failure path so the language server can survive unresolved imports during editor analysis.

## Change
- return a dummy node from `parse_import()` when resolution failed and fault-tolerant parsing has already reported the error

## Verification
- rebuilt and installed `zc`
- exercised `zc lsp` against a file containing `import "invalid.hh";`
- confirmed the server stays alive across restart/open cycles instead of failing the import path
